### PR TITLE
Fix duplicate user status entry error

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 // src/App.jsx
 import React, { useEffect, useState } from "react";
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Routes,
   Route,
   Navigate,


### PR DESCRIPTION
Fix E11000 duplicate key error on user status updates, remove redundant backend code, and resolve S3 404s for deep links by switching to HashRouter.

The E11000 error occurred because the `today` field in `UserStatus` was not consistently normalized to midnight UTC for the user's timezone, and updates were not atomic, leading to multiple documents for the same user on the same day. The fix ensures atomic upserts and correct `today` field calculation. The frontend change addresses S3's inability to handle `BrowserRouter`'s expected server-side routing for deep links, causing 404s.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d13e755-fcae-4513-b87f-5e896b37c903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d13e755-fcae-4513-b87f-5e896b37c903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

